### PR TITLE
Using README.rst instead of README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,53 @@
+xkcd v2.3.2 - A Python interface to xkcd.com
+============================================
+
+By Ben Rosser, released under MIT License (see LICENSE.txt)
+
+This is a Python library for accessing and retrieving links to comics
+from the xkcd webcomic by Randall Munroe. It is NOT endorsed or made by
+him, it's an entirely independent project.
+
+It makes use of the JSON interface to Randall's site to retrieve comic
+data. One can create comic objects manually using Comic(number), or can
+use the helper functions provided- getLatestComic(), getRandomComic(),
+and getComic()- to do this. Once you have a Comic object, you can access
+data from it using various provided methods.
+
+Documentation is available `here <https://pythonhosted.org/xkcd/>`__.
+
+Changelog:
+----------
+
+Version 2.3.2:
+~~~~~~~~~~~~~~
+
+-  Fixed distutils URL to point at TC01/python-xkcd, not TC01/xkcd.
+-  Started using pypandoc to dynamically turn README.md into a RST
+   long-description.
+
+Version 2.3:
+~~~~~~~~~~~~
+
+-  Fixed ASCII bug in Python 2.x
+-  Created Sphinx documentation and uploaded it to pythonhosted.org
+
+Version 2.2:
+~~~~~~~~~~~~
+
+-  Fixed very silly bug with xkcd.getComic()
+-  Added a getExplanation() which returns an explainxkcd link for a
+   Comic().
+-  Added support for Python 3!
+
+Version 2.1:
+~~~~~~~~~~~~
+
+-  Fixed bugs with Comic.download() function
+-  Added optional parameter to Comic.download() to change name of output
+   file
+-  Added more information to long\_description text
+
+Credits:
+--------
+
+-  Ben Rosser rosser.bjr@gmail.com: Developer

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,8 @@
 # Based from http://pythonhosted.org/setuptools/setuptools.html#automatic-script-creation
 
-from setuptools import setup, find_packages  # Always prefer setuptools over distutils
+from setuptools import setup  # Always prefer setuptools over distutils
 from codecs import open  # To use a consistent encoding
 from os import path
-
-# Depend on pypandoc for turning markdown readme into RST because
-# PyPI doesn't yet support this.
-import pypandoc
 
 here = path.abspath(path.dirname(__file__))
 
@@ -14,7 +10,8 @@ here = path.abspath(path.dirname(__file__))
 #with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 #	long_description = f.read()
 
-long_description = pypandoc.convert("README.md", "rst")
+with open("README.rst", "r", "utf-8") as f:
+	long_description = f.read()
 
 setup(
 	name='xkcd',


### PR DESCRIPTION
Requiring pypandoc to be installed for the setup.py causes empty venv to install a 20MB package for nothing.

```
$ pip install xkcd
Collecting xkcd
  Using cached xkcd-2.3.2.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-j4edysna/xkcd/setup.py", line 9, in <module>
        import pypandoc
    ImportError: No module named 'pypandoc
```

ping @minimata