### PR TITLE
Comic Number and Comic Date

### DIFF
--- a/xkcd.py
+++ b/xkcd.py
@@ -200,6 +200,10 @@ class Comic:
 		self.title = xkcdData['safe_title']
 		self.altText = xkcdData['alt']
 		self.imageLink = xkcdData['img']
+		self.imageNum = xkcdData['num']
+                self.day = xkcdData['day']
+                self.month = xkcdData['month']
+                self.year = xkcdData['year']
 
 		# This may no longer be necessary.
 #		if sys.version_info[0] >= 3:
@@ -268,6 +272,14 @@ class Comic:
 			a given comic and returns that URL."""
 		global explanationUrl
 		return explanationUrl + str(self.number)
+	
+	def getImageNumber(self):
+            """ Returns the Comic number."""
+            return self.imageNum
+
+        def getParsedDate(self):
+            """ Returns Comic date."""
+            return self.date
 
 	def show(self):
 		"""	Uses the Python webbrowser module to open the comic in your system's

--- a/xkcd.py
+++ b/xkcd.py
@@ -380,10 +380,10 @@ class Comic:
 		self.year = xkcdData['year']
 
 		# This may no longer be necessary.
-		# if sys.version_info[0] >= 3:
-		# self.title = str(self.title, encoding='UTF-8')
-		# self.altText = str(self.altText, encoding='UTF-8')
-		# self.imageLink = str(self.imageLink, encoding='UTF-8')
+#		if sys.version_info[0] >= 3:
+#			self.title = str(self.title, encoding='UTF-8')
+#			self.altText = str(self.altText, encoding='UTF-8')
+#			self.imageLink = str(self.imageLink, encoding='UTF-8')
 
 		#Get the image filename
 		offset = len(imageUrl)

--- a/xkcd.py
+++ b/xkcd.py
@@ -380,10 +380,10 @@ class Comic:
         self.year = xkcdData['year']
 
 		# This may no longer be necessary.
-#		if sys.version_info[0] >= 3:
-#			self.title = str(self.title, encoding='UTF-8')
-#			self.altText = str(self.altText, encoding='UTF-8')
-#			self.imageLink = str(self.imageLink, encoding='UTF-8')
+        # if sys.version_info[0] >= 3:
+        # self.title = str(self.title, encoding='UTF-8')
+        # self.altText = str(self.altText, encoding='UTF-8')
+        # self.imageLink = str(self.imageLink, encoding='UTF-8')
 
 		#Get the image filename
 		offset = len(imageUrl)
@@ -451,9 +451,20 @@ class Comic:
             """ Returns the Comic number."""
             return self.imageNum
 
-        def getParsedDate(self):
-            """ Returns Comic date."""
-            return self.date
+    # Possible date formats:
+    # YMD: year, month, day
+    # DMY: day, month, year
+    # MDY: month, day, year
+    def getParsedDate(self, dateType="MDY"):
+        """ Returns Comic date."""
+        if dateType == "MYD":
+            return "{}/{}/{}".format(self.month, self.year, self.day)
+        elif dateType == "DMY":
+            return "{}/{}/{}".format(self.day, self.month, self.year)
+        elif dateType == "MDY":
+            return "{}/{}/{}".format(self.month, self.day, self.year)
+        else:
+            return "{}/{}/{}".format(self.month, self.day, self.year)
 
 	def show(self):
 		"""	Uses the Python webbrowser module to open the comic in your system's
@@ -501,4 +512,3 @@ class Comic:
 		download.write(image)
 		download.close()
 		return output
-        

--- a/xkcd.py
+++ b/xkcd.py
@@ -447,15 +447,15 @@ class Comic:
 		global explanationUrl
 		return explanationUrl + str(self.number)
 	
-	def getImageNumber(self):
-			""" Returns the Comic number."""
-			return self.imageNum
+	def getNumber(self):
+		""" Returns the Comic number."""
+		return self.imageNum
 
 	# Possible date formats:
 	# YMD: year, month, day
 	# DMY: day, month, year
 	# MDY: month, day, year
-	def getParsedDate(self, dateType="MDY"):
+	def getDate(self, dateType="MDY"):
 		""" Returns Comic date."""
 		if dateType == "MYD":
 			return "{}/{}/{}".format(self.month, self.year, self.day)

--- a/xkcd.py
+++ b/xkcd.py
@@ -375,15 +375,15 @@ class Comic:
 		self.altText = xkcdData['alt']
 		self.imageLink = xkcdData['img']
 		self.imageNum = xkcdData['num']
-        self.day = xkcdData['day']
-        self.month = xkcdData['month']
-        self.year = xkcdData['year']
+		self.day = xkcdData['day']
+		self.month = xkcdData['month']
+		self.year = xkcdData['year']
 
 		# This may no longer be necessary.
-        # if sys.version_info[0] >= 3:
-        # self.title = str(self.title, encoding='UTF-8')
-        # self.altText = str(self.altText, encoding='UTF-8')
-        # self.imageLink = str(self.imageLink, encoding='UTF-8')
+		# if sys.version_info[0] >= 3:
+		# self.title = str(self.title, encoding='UTF-8')
+		# self.altText = str(self.altText, encoding='UTF-8')
+		# self.imageLink = str(self.imageLink, encoding='UTF-8')
 
 		#Get the image filename
 		offset = len(imageUrl)
@@ -448,23 +448,23 @@ class Comic:
 		return explanationUrl + str(self.number)
 	
 	def getImageNumber(self):
-            """ Returns the Comic number."""
-            return self.imageNum
+			""" Returns the Comic number."""
+			return self.imageNum
 
-    # Possible date formats:
-    # YMD: year, month, day
-    # DMY: day, month, year
-    # MDY: month, day, year
-    def getParsedDate(self, dateType="MDY"):
-        """ Returns Comic date."""
-        if dateType == "MYD":
-            return "{}/{}/{}".format(self.month, self.year, self.day)
-        elif dateType == "DMY":
-            return "{}/{}/{}".format(self.day, self.month, self.year)
-        elif dateType == "MDY":
-            return "{}/{}/{}".format(self.month, self.day, self.year)
-        else:
-            return "{}/{}/{}".format(self.month, self.day, self.year)
+	# Possible date formats:
+	# YMD: year, month, day
+	# DMY: day, month, year
+	# MDY: month, day, year
+	def getParsedDate(self, dateType="MDY"):
+		""" Returns Comic date."""
+		if dateType == "MYD":
+			return "{}/{}/{}".format(self.month, self.year, self.day)
+		elif dateType == "DMY":
+			return "{}/{}/{}".format(self.day, self.month, self.year)
+		elif dateType == "MDY":
+			return "{}/{}/{}".format(self.month, self.day, self.year)
+		else:
+			return "{}/{}/{}".format(self.month, self.day, self.year)
 
 	def show(self):
 		"""	Uses the Python webbrowser module to open the comic in your system's


### PR DESCRIPTION
# Added two functions to the `Comic` class:

### Get Date
```py
getDate(dateType="MDY")
```
Returns the comic's date in one of three formats, defaulting to Month/Day/Year
Possible formats:
* Month/Year/Day `MYD`
* Day/Month/Year `DMY`
* Month/Day/Year `MDY`

More formats are easily added, I just chose the most used ones globally.

### Get Comic Number
```py
getNumber()
```
Pretty simple, returns the comic's number. Just a nice quality of life thing for people who use the API.

### Further Changes:
Moved function definitions before class definitions, mostly to make my editor stop screaming at me.

### Formatting
My formatting might be off, as I usually use spaces, but if there are any problems that I missed, they'll be easy enough to fix